### PR TITLE
Add color and shorten minibuffer prompt.

### DIFF
--- a/visual-regexp.el
+++ b/visual-regexp.el
@@ -823,10 +823,14 @@ E [not supported in visual-regexp]"
          (cumulative-offset 0)
          (recenter-last-op nil) ; Start cycling order with initial position.
          (message
-          (apply 'propertize
-                 (substitute-command-keys
-                  "Query replacing %s with %s: (\\<vr--query-replace-map>\\[help] for help) ")
-                 minibuffer-prompt-properties)))
+          (concat
+           (propertize "Replacing " 'read-only t)
+           (propertize "%s" 'read-only t 'face 'font-lock-keyword-face)
+           (propertize " with " 'read-only t)
+           (propertize "%s" 'read-only t 'face 'font-lock-keyword-face)
+           (propertize (substitute-command-keys
+                        " (\\<vr--query-replace-map>\\[help] for help) ")
+                       'read-only t))))
 
     ;; show visual feedback for all matches
     (mapc (lambda (replacement-info)


### PR DESCRIPTION
When I'm using `vr/query-replace` with larger patterns, it can be hard to see what's going on in the minibuffer. I've made the message slightly shorter. I've also added some color to distinguish user input from the message.

Before:

![vr_query_replace_prompt_before](https://cloud.githubusercontent.com/assets/70800/11607853/45d40780-9b4f-11e5-8fb3-9147a52c81b8.png)

After:

![vr_query_replace_new_prompt](https://cloud.githubusercontent.com/assets/70800/11607855/55319e40-9b4f-11e5-9293-3a8cf892a6a5.png)