### PR TITLE
Add a hook after vr/replace vr/query-replace

### DIFF
--- a/visual-regexp.el
+++ b/visual-regexp.el
@@ -221,6 +221,9 @@ If nil, don't limit the number of matches shown in visual feedback."
 (defvar vr/initialize-hook nil
   "Hook called before vr/replace and vr/query-replace")
 
+(defvar vr/end-hook nil
+  "Hook called after vr/replace and vr/query-replace")
+
 ;;; private variables
 
 (defconst vr--match-faces '(vr/match-0 vr/match-1)
@@ -773,7 +776,8 @@ visible all the time in the minibuffer."
       (unless (overlayp vr--minibuffer-message-overlay)
         (delete-overlay vr--minibuffer-message-overlay))
       (vr--delete-overlay-displays)
-      (vr--delete-overlays))))
+      (vr--delete-overlays)
+      (run-hooks 'vr/end-hook))))
 
 (add-hook 'multiple-cursors-mode-enabled-hook
           ;; run vr/mc-mark once per cursor by default (do not ask the user)


### PR DESCRIPTION
Hi Benma,

Here an additional hook after `vr/replace` and `vr/query-replace`.

I use this patch with firstly `taoline` and then with `feebleline`. 
They also uses extensively the echo area and so they need to be neutralized before using a `visual-regexp` command; and restored after; otherwise they will conflict with `visual-regexp` and it will not display its visual feedback.

This hook allows me to do so without totally deactivating their mode (and so keeping an interface without modeline along using visual-regexp).